### PR TITLE
Update imports for Wagtail admin compatibility with Wagtail>=7.1

### DIFF
--- a/wagtailiconchooser/widgets.py
+++ b/wagtailiconchooser/widgets.py
@@ -1,8 +1,8 @@
 import json
 
 from django.forms import widgets, Media
-from wagtail.telepath import register
-from wagtail.widget_adapters import WidgetAdapter
+from wagtail.admin.telepath import register
+from wagtail.admin.telepath.widgets import WidgetAdapter
 
 
 class IconChooserWidget(widgets.TextInput):


### PR DESCRIPTION
Reference  [Wagtail 7.1 release notes](https://docs.wagtail.org/en/7.1/releases/7.1.html#wagtail-telepath-and-wagtail-widget-adapters-moved-to-wagtail-admin-telepath)