### PR TITLE
Make icon search case-insensitive

### DIFF
--- a/wagtailiconchooser/static/wagtailiconchooser/js/icon-chooser-widget.js
+++ b/wagtailiconchooser/static/wagtailiconchooser/js/icon-chooser-widget.js
@@ -140,7 +140,7 @@ IconChooserWidget.prototype.createIconSvgEl = function (iconId) {
 
 
 IconChooserWidget.prototype.handleIconListFilter = function (e) {
-    const value = e.target.value
+    const value = e.target.value.toLowerCase()
     this.modalIconsContent.find("div").filter(function () {
         $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
     });


### PR DESCRIPTION
To test:
1. Activate your climweb venv and install this fork in editable mode (`pip install -e /path/to/wagtail-icon-chooser`). Remember to switch to the proper branch.
2. Run the development server.
3. Open any icon chooser widget and perform a search with capital letters.
4. The search works in any capitalization.

<img width="1368" height="329" alt="image" src="https://github.com/user-attachments/assets/c41faff3-adba-4721-a76b-90efdab7534d" />
<img width="1379" height="330" alt="image" src="https://github.com/user-attachments/assets/3ba220cf-3a0d-4465-a407-96653153487f" />
<img width="1392" height="346" alt="image" src="https://github.com/user-attachments/assets/d1d0ff83-eeda-4c20-82d5-7af9b5f8936c" />
<img width="1362" height="341" alt="image" src="https://github.com/user-attachments/assets/9d5fa4d8-ee25-426e-a9a5-7752e858a3f9" />

Fixes wmo-raf/climweb#146